### PR TITLE
Feature: Test using selenium hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+
+# Created by https://www.gitignore.io/api/direnv
+# Edit at https://www.gitignore.io/?templates=direnv
+
+### direnv ###
+.direnv
+.envrc
+
+# End of https://www.gitignore.io/api/direnv
+

--- a/.github/workflows/robot-docker-compose-outside.yaml
+++ b/.github/workflows/robot-docker-compose-outside.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Combine test results
         if: ${{ always() }}
-        run: rebot --name "Browser Compotibility" --outputdir test-results test-results/*/output.xml
+        run: rebot --name "Browser Compatibility" --outputdir test-results test-results/*/output.xml
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2

--- a/.github/workflows/robot-docker-compose-outside.yaml
+++ b/.github/workflows/robot-docker-compose-outside.yaml
@@ -26,14 +26,18 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run Chrome tests
-        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER login_tests
+        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER --name $BROWSER login_tests
         env:
           BROWSER: chrome
 
       - name: Run Firefox tests
-        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER login_tests
+        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER --name $BROWSER login_tests
         env:
           BROWSER: firefox
+
+      - name: Combine test results
+        if: ${{ always() }}
+        run: rebot --name "Browser Compotibility" --outputdir test-results test-results/*/output.xml
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2

--- a/.github/workflows/robot-docker-compose-outside.yaml
+++ b/.github/workflows/robot-docker-compose-outside.yaml
@@ -26,12 +26,26 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run Chrome tests
-        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER --name $BROWSER login_tests
+        run: |
+          robot \
+            -v BROWSER:$BROWSER \
+            -v REMOTE_URL:$HUB_HOST \
+            -v SERVER:application:7272 \
+            --outputdir test-results/$BROWSER \
+            --name $BROWSER \
+            login_tests
         env:
           BROWSER: chrome
 
       - name: Run Firefox tests
-        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER --name $BROWSER login_tests
+        run: |
+          robot \
+            -v BROWSER:$BROWSER \
+            -v REMOTE_URL:$HUB_HOST \
+            -v SERVER:application:7272 \
+            --outputdir test-results/$BROWSER \
+            --name $BROWSER \
+            login_tests
         env:
           BROWSER: firefox
 

--- a/.github/workflows/robot-docker-compose-outside.yaml
+++ b/.github/workflows/robot-docker-compose-outside.yaml
@@ -26,11 +26,18 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run Chrome tests
-        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 login_tests
+        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER login_tests
         env:
           BROWSER: chrome
 
       - name: Run Firefox tests
-        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 login_tests
+        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 --outputdir test-results/$BROWSER login_tests
         env:
           BROWSER: firefox
+
+      - name: Store generated reports
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}  # Make sure to always collect the reports
+        with:
+          name: test-results
+          path: test-results/

--- a/.github/workflows/robot-docker-compose-outside.yaml
+++ b/.github/workflows/robot-docker-compose-outside.yaml
@@ -1,0 +1,36 @@
+name: RF Selenium Hub
+
+on: push
+
+jobs:
+  test-outside:
+    name: Test outside Docker Compose
+
+    runs-on: ubuntu-18.04
+    
+    env:
+      HUB_HOST: http://localhost:4444/wd/hub
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Start Docker Compose
+        run: docker-compose up -d
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install requirements
+        run: pip install -r requirements.txt
+
+      - name: Run Chrome tests
+        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 login_tests
+        env:
+          BROWSER: chrome
+
+      - name: Run Firefox tests
+        run: robot -v BROWSER:$BROWSER -v REMOTE_URL:$HUB_HOST -v SERVER:application:7272 login_tests
+        env:
+          BROWSER: firefox

--- a/.github/workflows/robot-docker-compose-outside.yaml
+++ b/.github/workflows/robot-docker-compose-outside.yaml
@@ -12,8 +12,7 @@ jobs:
       HUB_HOST: http://localhost:4444/wd/hub
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Start Docker Compose
         run: docker-compose up -d

--- a/.github/workflows/robot-docker-compose.yaml
+++ b/.github/workflows/robot-docker-compose.yaml
@@ -19,14 +19,18 @@ jobs:
         run: sleep 10
 
       - name: Run Chrome tests
-        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir test-results/$BROWSER /tests/login_tests
+        run: docker-compose run -T --entrypoint robot -v $(pwd)/test-results:/test-results/ -v $(pwd)/login_tests/:/tests/login_tests/ application -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir /test-results/$BROWSER --name $BROWSER /tests/login_tests/
         env:
           BROWSER: chrome
 
       - name: Run Firefox tests
-        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir test-results/$BROWSER /tests/login_tests
+        run: docker-compose run -T --entrypoint robot -v $(pwd)/test-results:/test-results/ -v $(pwd)/login_tests/:/tests/login_tests/ application -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir /test-results/$BROWSER --name $BROWSER /tests/login_tests/
         env:
           BROWSER: firefox
+
+      - name: Combine test results
+        if: ${{ always() }}
+        run: docker-compose run -T --entrypoint rebot -v $(pwd)/test-results:/test-results/ application --name "Browser Compatibility" --outputdir /test-results /test-results/*/output.xml
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2

--- a/.github/workflows/robot-docker-compose.yaml
+++ b/.github/workflows/robot-docker-compose.yaml
@@ -19,11 +19,18 @@ jobs:
         run: sleep 10
 
       - name: Run Chrome tests
-        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 /tests/login_tests
+        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir test-results/$BROWSER /tests/login_tests
         env:
           BROWSER: chrome
 
       - name: Run Firefox tests
-        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 /tests/login_tests
+        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir test-results/$BROWSER /tests/login_tests
         env:
           BROWSER: firefox
+
+      - name: Store generated reports
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}  # Make sure to always collect the reports
+        with:
+          name: test-results
+          path: test-results/

--- a/.github/workflows/robot-docker-compose.yaml
+++ b/.github/workflows/robot-docker-compose.yaml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Start Docker Compose
         run: docker-compose up -d

--- a/.github/workflows/robot-docker-compose.yaml
+++ b/.github/workflows/robot-docker-compose.yaml
@@ -19,18 +19,47 @@ jobs:
         run: sleep 10
 
       - name: Run Chrome tests
-        run: docker-compose run -T --entrypoint robot -v $(pwd)/test-results:/test-results/ -v $(pwd)/login_tests/:/tests/login_tests/ application -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir /test-results/$BROWSER --name $BROWSER /tests/login_tests/
+        run: |
+          docker-compose run -T \
+            --entrypoint robot \
+            -v $(pwd)/test-results:/test-results/ \
+            -v $(pwd)/login_tests/:/tests/login_tests/ \
+            application \
+            -v BROWSER:$BROWSER \
+            -v REMOTE_URL:http://selenium-hub:4444/wd/hub \
+            -v SERVER:application:7272 \
+            --outputdir /test-results/$BROWSER \
+            --name $BROWSER \
+            /tests/login_tests/
         env:
           BROWSER: chrome
 
       - name: Run Firefox tests
-        run: docker-compose run -T --entrypoint robot -v $(pwd)/test-results:/test-results/ -v $(pwd)/login_tests/:/tests/login_tests/ application -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 --outputdir /test-results/$BROWSER --name $BROWSER /tests/login_tests/
+        run: |
+          docker-compose run -T \
+            --entrypoint robot \
+            -v $(pwd)/test-results:/test-results/ \
+            -v $(pwd)/login_tests/:/tests/login_tests/ \
+            application \
+            -v BROWSER:$BROWSER \
+            -v REMOTE_URL:http://selenium-hub:4444/wd/hub \
+            -v SERVER:application:7272 \
+            --outputdir /test-results/$BROWSER \
+            --name $BROWSER \
+            /tests/login_tests/
         env:
           BROWSER: firefox
 
       - name: Combine test results
         if: ${{ always() }}
-        run: docker-compose run -T --entrypoint rebot -v $(pwd)/test-results:/test-results/ application --name "Browser Compatibility" --outputdir /test-results /test-results/*/output.xml
+        run: |
+          docker-compose run -T \
+            --entrypoint rebot \
+            -v $(pwd)/test-results:/test-results/ \
+            application \
+            --name "Browser Compatibility" \
+            --outputdir /test-results \
+            /test-results/*/output.xml
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2

--- a/.github/workflows/robot-docker-compose.yaml
+++ b/.github/workflows/robot-docker-compose.yaml
@@ -1,0 +1,29 @@
+name: RF Selenium Hub
+
+on: push
+
+jobs:
+  test-inside:
+    name: Test inside Docker Compose
+
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Start Docker Compose
+        run: docker-compose up -d
+
+      - name: Give the browsers time to connect to Selenium Hub
+        run: sleep 10
+
+      - name: Run Chrome tests
+        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 /tests/login_tests
+        env:
+          BROWSER: chrome
+
+      - name: Run Firefox tests
+        run: docker-compose exec -T application robot -v BROWSER:$BROWSER -v REMOTE_URL:http://selenium-hub:4444/wd/hub -v SERVER:application:7272 /tests/login_tests
+        env:
+          BROWSER: firefox

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -45,11 +45,12 @@ jobs:
             -v REMOTE_URL:http://hub:4444/wd/hub \
             -v SERVER:application:7272 \
             --outputdir test-results \
+            --name ${{ matrix.browser }}-python${{matrix.python-version}} \
             login_tests
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: ${{ matrix.browser }}-py${{ matrix.python-version }}-test-results
+          name: ${{ matrix.browser }}-python${{ matrix.python-version }}-test-results
           path: test-results

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -39,7 +39,13 @@ jobs:
         run: python demoapp/server.py &
 
       - name: Test
-        run: robot -v BROWSER:${{ matrix.browser }} -v REMOTE_URL:http://hub:4444/wd/hub -v SERVER:application:7272 --outputdir test-results login_tests
+        run: |
+          robot \
+            -v BROWSER:${{ matrix.browser }} \
+            -v REMOTE_URL:http://hub:4444/wd/hub \
+            -v SERVER:application:7272 \
+            --outputdir test-results \
+            login_tests
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -53,3 +53,32 @@ jobs:
         with:
           name: ${{ matrix.browser }}-python${{ matrix.python-version }}-test-results
           path: test-results
+
+  combine-reports:
+    name: Combine reports
+
+    runs-on: ubuntu-18.04
+
+    needs: [ matrix ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install Robot Framework
+        # Retrieves the same version of RF as is specified in our requirements file
+        run: pip install robotframework -c requirements.txt
+
+      - uses: actions/download-artifact@v2
+        
+      - name: Combine test results
+        run: rebot --name "Browser Compatibility" --outputdir combined-results */output.xml
+
+      - name: Store generated reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: combined-test-results
+          path: combined-results

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -3,7 +3,7 @@ name: RF Selenium Hub
 on: push
 
 jobs:
- matrix:
+  matrix:
     name: Matrix
 
     runs-on: ubuntu-18.04
@@ -29,8 +29,7 @@ jobs:
           HUB_PORT: 4444
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Install requirements
         run: pip install -r requirements.txt

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -39,10 +39,11 @@ jobs:
         run: python demoapp/server.py &
 
       - name: Test
-        run: robot -v BROWSER:${{ matrix.browser }} -v REMOTE_URL:http://hub:4444/wd/hub -v SERVER:application:7272 login_tests
+        run: robot -v BROWSER:${{ matrix.browser }} -v REMOTE_URL:http://hub:4444/wd/hub -v SERVER:application:7272 --outputdir test-results login_tests
 
       - name: Store generated reports
         uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
-          name: ${{ matrix.browser }}-py${{ matrix.python-version }}-reports
-          path: ./{output.xml,report.html,log.html}
+          name: ${{ matrix.browser }}-py${{ matrix.python-version }}-test-results
+          path: test-results

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -1,0 +1,42 @@
+name: RF Selenium Hub
+
+on: push
+
+jobs:
+ matrix:
+    name: Matrix
+
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8' ]
+        browser: ['chrome', 'firefox']
+
+    container:
+      image: python:${{ matrix.python-version }}-slim
+      # Set an alias for the container which is executing the "steps",
+      # as the Selenium Browser will need it as its hostname to connect to.
+      options: --network-alias application
+    
+    services:
+      hub:
+        image: selenium/hub:3.141.59-20200515
+      browser:
+        image: selenium/node-${{ matrix.browser }}:3.141.59-20200515
+        env:
+          HUB_HOST: hub
+          HUB_PORT: 4444
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install requirements
+        run: pip install -r requirements.txt
+
+      - name: Launch our webserver in the background
+        run: python demoapp/server.py &
+
+      - name: Test
+        run: robot -v BROWSER:${{ matrix.browser }} -v REMOTE_URL:http://hub:4444/wd/hub -v SERVER:application:7272 login_tests

--- a/.github/workflows/robot-matrix.yaml
+++ b/.github/workflows/robot-matrix.yaml
@@ -40,3 +40,9 @@ jobs:
 
       - name: Test
         run: robot -v BROWSER:${{ matrix.browser }} -v REMOTE_URL:http://hub:4444/wd/hub -v SERVER:application:7272 login_tests
+
+      - name: Store generated reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.browser }}-py${{ matrix.python-version }}-reports
+          path: ./{output.xml,report.html,log.html}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3
+
+WORKDIR /app
+
+# Install requirements
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Copy source code
+COPY demoapp/ ./demoapp/
+
+EXPOSE 7272
+
+ENTRYPOINT ["python", "demoapp/server.py"]

--- a/demoapp/server.py
+++ b/demoapp/server.py
@@ -34,7 +34,7 @@ class DemoServer(ThreadingMixIn, HTTPServer):
     allow_reuse_address = True
 
     def __init__(self, port=PORT):
-        HTTPServer.__init__(self, ('localhost', int(port)),
+        HTTPServer.__init__(self, ('0.0.0.0', int(port)),
                             SimpleHTTPRequestHandler)
 
     def serve(self, directory=ROOT):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3"
+services:
+  application:
+    build: .
+    volumes:
+      - ./login_tests/:/tests/login_tests/
+    restart: always
+    ports:
+      - 7272:7272
+
+  selenium-hub:
+    image: selenium/hub:3.141.59-20200515
+    container_name: selenium-hub
+    ports:
+      - 4444:4444
+
+  chrome:
+    image: selenium/node-chrome:3.141.59-20200515
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+
+  firefox:
+    image: selenium/node-firefox:3.141.59-20200515
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+  opera:
+    image: selenium/node-opera:3.141.59-20200515
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   application:
     build: .
-    restart: always
+    restart: unless-stopped
     ports:
       - 7272:7272
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,12 +33,3 @@ services:
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
-  opera:
-    image: selenium/node-opera:3.141.59-20200515
-    volumes:
-      - /dev/shm:/dev/shm
-    depends_on:
-      - selenium-hub
-    environment:
-      - HUB_HOST=selenium-hub
-      - HUB_PORT=4444

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: "3"
 services:
   application:
     build: .
-    volumes:
-      - ./login_tests/:/tests/login_tests/
     restart: always
     ports:
       - 7272:7272

--- a/login_tests/resource.robot
+++ b/login_tests/resource.robot
@@ -9,6 +9,7 @@ Library           SeleniumLibrary
 *** Variables ***
 ${SERVER}         localhost:7272
 ${BROWSER}        Firefox
+${REMOTE_URL}     False
 ${DELAY}          0
 ${VALID USER}     demo
 ${VALID PASSWORD}    mode
@@ -18,7 +19,7 @@ ${ERROR URL}      http://${SERVER}/error.html
 
 *** Keywords ***
 Open Browser To Login Page
-    Open Browser    ${LOGIN URL}    ${BROWSER}
+    Open Browser    ${LOGIN URL}    ${BROWSER}  	remote_url=${REMOTE_URL}
     Maximize Browser Window
     Set Selenium Speed    ${DELAY}
     Login Page Should Be Open


### PR DESCRIPTION
This PR contains:
- Changes needed to get the WebDemo to work with Selenium Hub.
- A Dockerfile and a Docker Compose configuration, as to be able to run Selenium Hub locally inside Docker.
- Three ways of running Selenium Hub on Github Actions:
    * Two use Docker Compose, here the difference is that one runs the tests inside Docker Compose, whilst the other does it locally.
     * The remaining one does **not** use Docker Compose - hence it also doesn't need the Dockerfile and Docker Compose files, instead the logic on how to orchestrate the application is included as part of the Github Actions definition. 